### PR TITLE
현재 프로젝트의 master로 배포하는 문제가 발생하여 현재 프로젝트 경로인 github.io/reponame 방식으로 수정

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,16 +1,17 @@
 module.exports = {
+  pathPrefix: '/WIL',
   siteMetadata: {
     title: 'What I Learned',
     description:
       '내가 무엇을 알고 모르는지 파악해보고, 다른 개발자에게 도움이 될 수 있는 지식을 전파하는 블로그',
     author: 'mhkim',
-    siteUrl: 'https://yahma25.github.io/',
+    siteUrl: 'https://yahma25.github.io/WIL',
   },
   plugins: [
     {
       resolve: 'gatsby-plugin-canonical-urls',
       options: {
-        siteUrl: 'https://yahma25.github.io/',
+        siteUrl: 'https://yahma25.github.io/WIL',
         stripQueryString: true,
       },
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
-    "deploy": "gatsby build && gh-pages -d public -b master"
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
공식 문서
* https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages/#deploying-to-a-path-on-github-pages