### PR TITLE
gatsby 배포 시 IntersectionObserver는 브라우저 API라서 인식하지 못하는 이유로 useEffect 내…

### DIFF
--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -32,19 +32,22 @@ const useInfiniteScroll = function (
     [selectedCategory],
   );
 
-  const observer: IntersectionObserver = new IntersectionObserver(
-    (entries, observer) => {
+  let observer: IntersectionObserver;
+
+  useEffect(() => {
+    observer = new IntersectionObserver((entries, observer) => {
       if (!entries[0].isIntersecting) return;
 
       setCount(count => count + 1);
       observer.disconnect();
-    },
-  );
+    });
+  });
 
   useEffect(() => setCount(1), [selectedCategory]);
 
   useEffect(() => {
     if (
+      observer == null ||
       count * NUMBER_IF_ITEMS_PER_PAGE >= articleListByCategory.length ||
       containerRef.current == null ||
       containerRef.current?.children.length === 0


### PR DESCRIPTION
…에서 생성하도록 수정